### PR TITLE
add the missing @Module annotation

### DIFF
--- a/app/src/debug/java/net/grzechocinski/android/dagger2example/internal/di/DebugDependenciesModule.java
+++ b/app/src/debug/java/net/grzechocinski/android/dagger2example/internal/di/DebugDependenciesModule.java
@@ -1,8 +1,11 @@
 package net.grzechocinski.android.dagger2example.internal.di;
 
-import dagger.Provides;
 import javax.inject.Singleton;
 
+import dagger.Module;
+import dagger.Provides;
+
+@Module
 public class DebugDependenciesModule {
 
     @Singleton


### PR DESCRIPTION
- without it, getting the errors:
  - "error: @Provides methods can only be present within a @Module"
  - "error: DebugDependenciesModule is listed as a module, but is not annotated with @Module"
- fixes issue #3 
