### PR TITLE
Modify to enable compilation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,3 +1,4 @@
+
 apply plugin: 'com.android.application'
 apply plugin: 'me.tatarka.retrolambda'
 apply plugin: 'com.neenbedankt.android-apt'
@@ -33,7 +34,7 @@ android {
     dependencies {
         compile 'com.android.support:appcompat-v7:22.0.0'
         compile 'com.jakewharton:butterknife:6.1.0'
-        compile 'com.google.dagger:dagger:2.0-SNAPSHOT'
+        compile 'com.google.dagger:dagger:2.0'
         compile 'com.jakewharton.timber:timber:2.7.1'
 
         testCompile ('com.squareup.assertj:assertj-android:1.0.0'){
@@ -43,7 +44,7 @@ android {
         testCompile 'org.mockito:mockito-core:2.0.5-beta'
 
         apt "org.projectlombok:lombok:1.16.2"
-        apt "com.google.dagger:dagger-compiler:2.0-SNAPSHOT"
+        apt "com.google.dagger:dagger-compiler:2.0"
 
         provided 'javax.annotation:jsr250-api:1.0'
         provided "org.projectlombok:lombok:1.16.2"

--- a/app/src/debug/java/net/grzechocinski/android/dagger2example/internal/di/DebugDependenciesModule.java
+++ b/app/src/debug/java/net/grzechocinski/android/dagger2example/internal/di/DebugDependenciesModule.java
@@ -1,8 +1,10 @@
 package net.grzechocinski.android.dagger2example.internal.di;
 
+import dagger.Module;
 import dagger.Provides;
 import javax.inject.Singleton;
 
+@Module
 public class DebugDependenciesModule {
 
     @Singleton

--- a/app/src/main/java/net/grzechocinski/android/dagger2example/D2EBaseApplication.java
+++ b/app/src/main/java/net/grzechocinski/android/dagger2example/D2EBaseApplication.java
@@ -5,7 +5,8 @@ import android.content.Context;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import net.grzechocinski.android.dagger2example.internal.di.D2EComponent;
-import net.grzechocinski.android.dagger2example.internal.di.Dagger_D2EComponent;
+
+import net.grzechocinski.android.dagger2example.internal.di.DaggerD2EComponent;
 import net.grzechocinski.android.dagger2example.internal.di.SystemServicesModule;
 
 public abstract class D2EBaseApplication extends Application {
@@ -30,7 +31,7 @@ public abstract class D2EBaseApplication extends Application {
     public final static class DaggerComponentInitializer {
 
         public static D2EComponent init(D2EBaseApplication app) {
-            return Dagger_D2EComponent.builder()
+            return DaggerD2EComponent.builder()
                     .systemServicesModule(new SystemServicesModule(app))
                     .build();
         }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:1.1.3'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.4'
-        classpath 'me.tatarka:gradle-retrolambda:2.5.0'
+        classpath 'me.tatarka:gradle-retrolambda:3.0.1'
     }
 }
 


### PR DESCRIPTION
Since Dagger2 is now officially released, we are no longer able to compile our project with dagger2 _SNAPSHOT_ version. Also, `@Module` annotation is required for Module class to successfully compile the project. 
